### PR TITLE
feat(cli): human-readable Persian month names in output

### DIFF
--- a/crates/shahanshahi-cli/src/cli.rs
+++ b/crates/shahanshahi-cli/src/cli.rs
@@ -35,6 +35,11 @@ pub struct ConvertArgs {
     #[arg(long)]
     pub proleptic: bool,
 
+    /// Display Shahanshahi month names instead of numeric month (e.g. "1 Farvardin 2535").
+    /// No-op when the output calendar is Gregorian.
+    #[arg(long)]
+    pub month_names: bool,
+
     /// Date in YYYY-MM-DD format (omit or pass "-" for stdin).
     pub date: Option<String>,
 }

--- a/crates/shahanshahi-cli/src/convert.rs
+++ b/crates/shahanshahi-cli/src/convert.rs
@@ -74,6 +74,36 @@ pub fn format_ymd(d: &DateTriple) -> String {
     format!("{:04}-{:02}-{:02}", d.year, d.month, d.day)
 }
 
+/// Returns the English transliteration of the Shahanshahi month name for a
+/// 1-based month index (1 = Farvardin … 12 = Esfand), as fixed by the 1925
+/// Iranian calendar law and listed in SPEC.md § Months.
+pub fn month_name(month: u8) -> &'static str {
+    const NAMES: [&str; 12] = [
+        "Farvardin",
+        "Ordibehesht",
+        "Khordad",
+        "Tir",
+        "Mordad",
+        "Shahrivar",
+        "Mehr",
+        "Aban",
+        "Azar",
+        "Dey",
+        "Bahman",
+        "Esfand",
+    ];
+    match month {
+        1..=12 => NAMES[(month - 1) as usize],
+        _ => "?",
+    }
+}
+
+/// Formats a date as `"D MonthName YYYY"` (e.g. `"1 Farvardin 2535"`).
+/// Intended for Shahanshahi output with `--month-names`.
+pub fn format_named(d: &DateTriple) -> String {
+    format!("{} {} {}", d.day, month_name(d.month), d.year)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -138,5 +168,36 @@ mod tests {
         let input = parse_ymd("1996-03-20").unwrap();
         let output = convert(input, &Calendar::Gregorian, &Calendar::Shahanshahi, true).unwrap();
         assert_eq!((output.year, output.month, output.day), (2555, 1, 1));
+    }
+
+    #[test]
+    fn month_name_all_twelve() {
+        let expected = [
+            "Farvardin", "Ordibehesht", "Khordad",
+            "Tir",       "Mordad",      "Shahrivar",
+            "Mehr",      "Aban",        "Azar",
+            "Dey",       "Bahman",      "Esfand",
+        ];
+        for (i, name) in expected.iter().enumerate() {
+            assert_eq!(month_name(i as u8 + 1), *name);
+        }
+    }
+
+    #[test]
+    fn month_name_out_of_range_returns_fallback() {
+        assert_eq!(month_name(0), "?");
+        assert_eq!(month_name(13), "?");
+    }
+
+    #[test]
+    fn format_named_produces_day_name_year() {
+        let d = DateTriple { year: 2535, month: 1, day: 1 };
+        assert_eq!(format_named(&d), "1 Farvardin 2535");
+    }
+
+    #[test]
+    fn format_named_last_month() {
+        let d = DateTriple { year: 2535, month: 12, day: 29 };
+        assert_eq!(format_named(&d), "29 Esfand 2535");
     }
 }

--- a/crates/shahanshahi-cli/src/convert.rs
+++ b/crates/shahanshahi-cli/src/convert.rs
@@ -173,10 +173,18 @@ mod tests {
     #[test]
     fn month_name_all_twelve() {
         let expected = [
-            "Farvardin", "Ordibehesht", "Khordad",
-            "Tir",       "Mordad",      "Shahrivar",
-            "Mehr",      "Aban",        "Azar",
-            "Dey",       "Bahman",      "Esfand",
+            "Farvardin",
+            "Ordibehesht",
+            "Khordad",
+            "Tir",
+            "Mordad",
+            "Shahrivar",
+            "Mehr",
+            "Aban",
+            "Azar",
+            "Dey",
+            "Bahman",
+            "Esfand",
         ];
         for (i, name) in expected.iter().enumerate() {
             assert_eq!(month_name(i as u8 + 1), *name);
@@ -191,13 +199,21 @@ mod tests {
 
     #[test]
     fn format_named_produces_day_name_year() {
-        let d = DateTriple { year: 2535, month: 1, day: 1 };
+        let d = DateTriple {
+            year: 2535,
+            month: 1,
+            day: 1,
+        };
         assert_eq!(format_named(&d), "1 Farvardin 2535");
     }
 
     #[test]
     fn format_named_last_month() {
-        let d = DateTriple { year: 2535, month: 12, day: 29 };
+        let d = DateTriple {
+            year: 2535,
+            month: 12,
+            day: 29,
+        };
         assert_eq!(format_named(&d), "29 Esfand 2535");
     }
 }

--- a/crates/shahanshahi-cli/src/format.rs
+++ b/crates/shahanshahi-cli/src/format.rs
@@ -174,12 +174,7 @@ fn run_json_batch(
     Ok(())
 }
 
-fn run_csv_batch(
-    from: &Calendar,
-    to: &Calendar,
-    proleptic: bool,
-    month_names: bool,
-) -> Result<()> {
+fn run_csv_batch(from: &Calendar, to: &Calendar, proleptic: bool, month_names: bool) -> Result<()> {
     let stdin = io::stdin();
     let mut rdr = csv::Reader::from_reader(stdin.lock());
 

--- a/crates/shahanshahi-cli/src/format.rs
+++ b/crates/shahanshahi-cli/src/format.rs
@@ -5,7 +5,8 @@ use std::io::{self, BufRead, Write};
 use crate::cli::{Calendar, Format};
 use crate::convert::{self, DateTriple};
 
-#[derive(Serialize, Deserialize)]
+// Input-only: used to parse year/month/day from JSON arrays and CSV rows.
+#[derive(Deserialize)]
 struct DateRecord {
     year: i32,
     month: u8,
@@ -13,14 +14,6 @@ struct DateRecord {
 }
 
 impl DateRecord {
-    fn from_triple(d: &DateTriple) -> Self {
-        Self {
-            year: d.year,
-            month: d.month,
-            day: d.day,
-        }
-    }
-
     fn into_triple(self) -> DateTriple {
         DateTriple {
             year: self.year,
@@ -30,21 +23,72 @@ impl DateRecord {
     }
 }
 
-pub fn write_single(format: &Format, output: &DateTriple) -> Result<()> {
+// Output without month names.
+#[derive(Serialize)]
+struct DateRecordOut {
+    year: i32,
+    month: u8,
+    day: u8,
+}
+
+impl DateRecordOut {
+    fn from_triple(d: &DateTriple) -> Self {
+        Self {
+            year: d.year,
+            month: d.month,
+            day: d.day,
+        }
+    }
+}
+
+// Output with month names; Serialize only — never parsed back from input.
+#[derive(Serialize)]
+struct DateRecordNamed {
+    year: i32,
+    month: u8,
+    month_name: &'static str,
+    day: u8,
+}
+
+impl DateRecordNamed {
+    fn from_triple(d: &DateTriple) -> Self {
+        Self {
+            year: d.year,
+            month: d.month,
+            month_name: convert::month_name(d.month),
+            day: d.day,
+        }
+    }
+}
+
+pub fn write_single(format: &Format, output: &DateTriple, month_names: bool) -> Result<()> {
     let stdout = io::stdout();
     let mut out = stdout.lock();
 
     match format {
         Format::Text => {
-            writeln!(out, "{}", convert::format_ymd(output))?;
+            let line = if month_names {
+                convert::format_named(output)
+            } else {
+                convert::format_ymd(output)
+            };
+            writeln!(out, "{line}")?;
         }
         Format::Json => {
-            serde_json::to_writer(&mut out, &DateRecord::from_triple(output))?;
+            if month_names {
+                serde_json::to_writer(&mut out, &DateRecordNamed::from_triple(output))?;
+            } else {
+                serde_json::to_writer(&mut out, &DateRecordOut::from_triple(output))?;
+            }
             writeln!(out)?;
         }
         Format::Csv => {
             let mut wtr = csv::Writer::from_writer(&mut out);
-            wtr.serialize(DateRecord::from_triple(output))?;
+            if month_names {
+                wtr.serialize(DateRecordNamed::from_triple(output))?;
+            } else {
+                wtr.serialize(DateRecordOut::from_triple(output))?;
+            }
             wtr.flush()?;
         }
     }
@@ -52,15 +96,26 @@ pub fn write_single(format: &Format, output: &DateTriple) -> Result<()> {
     Ok(())
 }
 
-pub fn run_batch(format: &Format, from: &Calendar, to: &Calendar, proleptic: bool) -> Result<()> {
+pub fn run_batch(
+    format: &Format,
+    from: &Calendar,
+    to: &Calendar,
+    proleptic: bool,
+    month_names: bool,
+) -> Result<()> {
     match format {
-        Format::Text => run_text_batch(from, to, proleptic),
-        Format::Json => run_json_batch(from, to, proleptic),
-        Format::Csv => run_csv_batch(from, to, proleptic),
+        Format::Text => run_text_batch(from, to, proleptic, month_names),
+        Format::Json => run_json_batch(from, to, proleptic, month_names),
+        Format::Csv => run_csv_batch(from, to, proleptic, month_names),
     }
 }
 
-fn run_text_batch(from: &Calendar, to: &Calendar, proleptic: bool) -> Result<()> {
+fn run_text_batch(
+    from: &Calendar,
+    to: &Calendar,
+    proleptic: bool,
+    month_names: bool,
+) -> Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
     let mut out = stdout.lock();
@@ -75,32 +130,56 @@ fn run_text_batch(from: &Calendar, to: &Calendar, proleptic: bool) -> Result<()>
             convert::parse_ymd(trimmed).with_context(|| format!("parsing line: {trimmed}"))?;
         let output = convert::convert(input, from, to, proleptic)
             .with_context(|| format!("converting: {trimmed}"))?;
-        writeln!(out, "{}", convert::format_ymd(&output))?;
+        let formatted = if month_names {
+            convert::format_named(&output)
+        } else {
+            convert::format_ymd(&output)
+        };
+        writeln!(out, "{formatted}")?;
     }
 
     Ok(())
 }
 
-fn run_json_batch(from: &Calendar, to: &Calendar, proleptic: bool) -> Result<()> {
+fn run_json_batch(
+    from: &Calendar,
+    to: &Calendar,
+    proleptic: bool,
+    month_names: bool,
+) -> Result<()> {
     let stdin = io::stdin();
     let records: Vec<DateRecord> =
         serde_json::from_reader(stdin.lock()).context("failed to parse JSON array from stdin")?;
 
-    let mut results = Vec::with_capacity(records.len());
-    for rec in records {
-        let output = convert::convert(rec.into_triple(), from, to, proleptic)?;
-        results.push(DateRecord::from_triple(&output));
-    }
-
     let stdout = io::stdout();
     let mut out = stdout.lock();
-    serde_json::to_writer(&mut out, &results)?;
+
+    if month_names {
+        let mut results = Vec::with_capacity(records.len());
+        for rec in records {
+            let output = convert::convert(rec.into_triple(), from, to, proleptic)?;
+            results.push(DateRecordNamed::from_triple(&output));
+        }
+        serde_json::to_writer(&mut out, &results)?;
+    } else {
+        let mut results = Vec::with_capacity(records.len());
+        for rec in records {
+            let output = convert::convert(rec.into_triple(), from, to, proleptic)?;
+            results.push(DateRecordOut::from_triple(&output));
+        }
+        serde_json::to_writer(&mut out, &results)?;
+    }
     writeln!(out)?;
 
     Ok(())
 }
 
-fn run_csv_batch(from: &Calendar, to: &Calendar, proleptic: bool) -> Result<()> {
+fn run_csv_batch(
+    from: &Calendar,
+    to: &Calendar,
+    proleptic: bool,
+    month_names: bool,
+) -> Result<()> {
     let stdin = io::stdin();
     let mut rdr = csv::Reader::from_reader(stdin.lock());
 
@@ -110,7 +189,11 @@ fn run_csv_batch(from: &Calendar, to: &Calendar, proleptic: bool) -> Result<()> 
     for result in rdr.deserialize() {
         let rec: DateRecord = result.context("failed to parse CSV row")?;
         let output = convert::convert(rec.into_triple(), from, to, proleptic)?;
-        wtr.serialize(DateRecord::from_triple(&output))?;
+        if month_names {
+            wtr.serialize(DateRecordNamed::from_triple(&output))?;
+        } else {
+            wtr.serialize(DateRecordOut::from_triple(&output))?;
+        }
     }
     wtr.flush()?;
 

--- a/crates/shahanshahi-cli/src/main.rs
+++ b/crates/shahanshahi-cli/src/main.rs
@@ -24,14 +24,16 @@ fn run() -> Result<()> {
 
 fn run_convert(args: ConvertArgs) -> Result<()> {
     let (from, to) = resolve_direction(args.from, args.to)?;
+    // Month names only apply to Shahanshahi output; silently no-op for Gregorian.
+    let use_month_names = args.month_names && to == Calendar::Shahanshahi;
 
     match args.date.as_deref() {
         Some(s) if s != "-" => {
             let input = convert::parse_ymd(s)?;
             let output = convert::convert(input, &from, &to, args.proleptic)?;
-            format::write_single(&args.format, &output)
+            format::write_single(&args.format, &output, use_month_names)
         }
-        _ => format::run_batch(&args.format, &from, &to, args.proleptic),
+        _ => format::run_batch(&args.format, &from, &to, args.proleptic, use_month_names),
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `--month-names` flag to the `convert` subcommand. When set, Shahanshahi output uses English transliterations of the month names fixed by the 1925 Iranian calendar law (SPEC.md § Months) instead of numeric month indices.

- Text: `1 Farvardin 2535` instead of `2535-01-01`
- JSON: adds `month_name` field alongside the numeric `month`
- CSV: adds `month_name` column alongside the numeric `month`
- Gregorian output: flag is silently a no-op

## Motivation

Month names are part of the calendar spec (fixed by law, in scope per SPEC.md) and make Shahanshahi dates immediately readable without a lookup table.

## How to verify

```bash
# Text
shahanshahi convert 1976-03-21 --month-names
# → 1 Farvardin 2535

# JSON (single)
shahanshahi convert 1976-03-21 --month-names --format json
# → {"year":2535,"month":1,"month_name":"Farvardin","day":1}

# CSV (single)
shahanshahi convert 1976-03-21 --month-names --format csv
# → year,month,month_name,day
# → 2535,1,Farvardin,1

# Gregorian output — no-op
shahanshahi convert 2535-01-01 --from shahanshahi --month-names
# → 1976-03-21

# Batch JSON
echo '[{"year":1976,"month":3,"day":21}]' | shahanshahi convert --month-names --format json
# → [{"year":2535,"month":1,"month_name":"Farvardin","day":1}]
```

## Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — 43 tests pass
- [x] Conventional Commit messages per commit
- [x] Closes #45