### PR TITLE
chore(claude): add project settings with cargo fmt post-edit hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // \"\"' | { read -r f; case \"$f\" in *.rs) cd \"$(git -C \"$(dirname \"$f\")\" rev-parse --show-toplevel)\" && cargo fmt --all;; esac; } 2>/dev/null || true",
+            "statusMessage": "Formatting Rust..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with a `PostToolUse` hook that auto-runs `cargo fmt --all` after any `Write|Edit` on a `.rs` file during Claude Code sessions.

## Motivation

We hit a rustfmt CI failure on PR #56 because formatting wasn't enforced locally. This hook mirrors the CI gate so formatting violations are caught immediately after each file edit — before committing.

The git pre-commit hook (`.git/hooks/pre-commit`) is a companion local safeguard but lives in `.git/` which is not tracked by git. Contributors who want it can add it manually:

```sh
echo '#!/bin/sh\ncargo fmt --all -- --check' > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
```

## How to verify

Open `/hooks` in Claude Code to confirm the hook is loaded. Edit any `.rs` file — the "Formatting Rust..." spinner should appear and the file should be formatted automatically.

## Checklist

- [x] `cargo fmt --all` — no Rust changes
- [x] `cargo clippy` — no Rust changes
- [x] `cargo test --workspace --all-features` — no Rust changes
- [x] Conventional Commit message