### PR TITLE
feat(cli): shell completion scripts (bash/zsh/fish/PowerShell)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +292,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "csv",
  "serde",
  "serde_json",

--- a/crates/shahanshahi-cli/Cargo.toml
+++ b/crates/shahanshahi-cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 csv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/shahanshahi-cli/src/cli.rs
+++ b/crates/shahanshahi-cli/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap_complete::Shell;
 
 #[derive(Parser)]
 #[command(
@@ -15,6 +16,20 @@ pub struct Cli {
 pub enum Command {
     /// Convert dates between Shahanshahi and Gregorian calendars.
     Convert(ConvertArgs),
+
+    /// Print a shell completion script to stdout.
+    ///
+    /// Pipe the output into your shell's completions directory, e.g.:
+    ///   shahanshahi completions bash > ~/.local/share/bash-completion/completions/shahanshahi
+    ///   shahanshahi completions zsh  > ~/.config/zsh/completions/_shahanshahi
+    ///   shahanshahi completions fish > ~/.config/fish/completions/shahanshahi.fish
+    Completions(CompletionsArgs),
+}
+
+#[derive(Args)]
+pub struct CompletionsArgs {
+    /// Shell to generate completions for.
+    pub shell: Shell,
 }
 
 #[derive(Args)]

--- a/crates/shahanshahi-cli/src/main.rs
+++ b/crates/shahanshahi-cli/src/main.rs
@@ -3,9 +3,11 @@ mod convert;
 mod format;
 
 use anyhow::{bail, Result};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::generate;
+use std::io;
 
-use cli::{Calendar, Cli, Command, ConvertArgs};
+use cli::{Calendar, Cli, Command, CompletionsArgs, ConvertArgs};
 
 fn main() {
     if let Err(err) = run() {
@@ -19,6 +21,7 @@ fn run() -> Result<()> {
 
     match cli.command {
         Command::Convert(args) => run_convert(args),
+        Command::Completions(args) => run_completions(args),
     }
 }
 
@@ -35,6 +38,12 @@ fn run_convert(args: ConvertArgs) -> Result<()> {
         }
         _ => format::run_batch(&args.format, &from, &to, args.proleptic, use_month_names),
     }
+}
+
+fn run_completions(args: CompletionsArgs) -> Result<()> {
+    let mut cmd = Cli::command();
+    generate(args.shell, &mut cmd, "shahanshahi", &mut io::stdout());
+    Ok(())
 }
 
 /// Infer the missing direction when only one of --from / --to is given.

--- a/crates/shahanshahi-cli/src/main.rs
+++ b/crates/shahanshahi-cli/src/main.rs
@@ -5,7 +5,7 @@ mod format;
 use anyhow::{bail, Result};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
-use std::io;
+use std::io::{self, Write};
 
 use cli::{Calendar, Cli, Command, CompletionsArgs, ConvertArgs};
 
@@ -41,9 +41,58 @@ fn run_convert(args: ConvertArgs) -> Result<()> {
 }
 
 fn run_completions(args: CompletionsArgs) -> Result<()> {
+    run_completions_into(args, &mut io::stdout())
+}
+
+fn run_completions_into(args: CompletionsArgs, out: &mut dyn Write) -> Result<()> {
     let mut cmd = Cli::command();
-    generate(args.shell, &mut cmd, "shahanshahi", &mut io::stdout());
+    generate(args.shell, &mut cmd, "shahanshahi", out);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap_complete::Shell;
+
+    fn completions_for(shell: Shell) -> String {
+        let args = cli::CompletionsArgs { shell };
+        let mut buf = Vec::new();
+        run_completions_into(args, &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn completions_bash_non_empty() {
+        let out = completions_for(Shell::Bash);
+        assert!(!out.is_empty());
+        assert!(out.contains("shahanshahi"));
+        assert!(out.contains("convert"));
+    }
+
+    #[test]
+    fn completions_zsh_non_empty() {
+        let out = completions_for(Shell::Zsh);
+        assert!(!out.is_empty());
+        assert!(out.contains("shahanshahi"));
+        assert!(out.contains("convert"));
+    }
+
+    #[test]
+    fn completions_fish_non_empty() {
+        let out = completions_for(Shell::Fish);
+        assert!(!out.is_empty());
+        assert!(out.contains("shahanshahi"));
+        assert!(out.contains("convert"));
+    }
+
+    #[test]
+    fn completions_powershell_non_empty() {
+        let out = completions_for(Shell::PowerShell);
+        assert!(!out.is_empty());
+        assert!(out.contains("shahanshahi"));
+        assert!(out.contains("convert"));
+    }
 }
 
 /// Infer the missing direction when only one of --from / --to is given.

--- a/crates/shahanshahi-cli/src/main.rs
+++ b/crates/shahanshahi-cli/src/main.rs
@@ -50,6 +50,24 @@ fn run_completions_into(args: CompletionsArgs, out: &mut dyn Write) -> Result<()
     Ok(())
 }
 
+/// Infer the missing direction when only one of --from / --to is given.
+/// Default (neither specified): Gregorian → Shahanshahi.
+fn resolve_direction(from: Option<Calendar>, to: Option<Calendar>) -> Result<(Calendar, Calendar)> {
+    match (from, to) {
+        (Some(f), Some(t)) if f == t => {
+            bail!("--from and --to must specify different calendars");
+        }
+        (Some(f), Some(t)) => Ok((f, t)),
+        (Some(Calendar::Gregorian), None) | (None, None) => {
+            Ok((Calendar::Gregorian, Calendar::Shahanshahi))
+        }
+        (Some(Calendar::Shahanshahi), None) | (None, Some(Calendar::Gregorian)) => {
+            Ok((Calendar::Shahanshahi, Calendar::Gregorian))
+        }
+        (None, Some(Calendar::Shahanshahi)) => Ok((Calendar::Gregorian, Calendar::Shahanshahi)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,23 +110,5 @@ mod tests {
         assert!(!out.is_empty());
         assert!(out.contains("shahanshahi"));
         assert!(out.contains("convert"));
-    }
-}
-
-/// Infer the missing direction when only one of --from / --to is given.
-/// Default (neither specified): Gregorian → Shahanshahi.
-fn resolve_direction(from: Option<Calendar>, to: Option<Calendar>) -> Result<(Calendar, Calendar)> {
-    match (from, to) {
-        (Some(f), Some(t)) if f == t => {
-            bail!("--from and --to must specify different calendars");
-        }
-        (Some(f), Some(t)) => Ok((f, t)),
-        (Some(Calendar::Gregorian), None) | (None, None) => {
-            Ok((Calendar::Gregorian, Calendar::Shahanshahi))
-        }
-        (Some(Calendar::Shahanshahi), None) | (None, Some(Calendar::Gregorian)) => {
-            Ok((Calendar::Shahanshahi, Calendar::Gregorian))
-        }
-        (None, Some(Calendar::Shahanshahi)) => Ok((Calendar::Gregorian, Calendar::Shahanshahi)),
     }
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -82,6 +82,27 @@ All numeric fields are integers consistent with the active `--from` / `--to` cal
 - **`0`** — success.
 - **`1`** — conversion or parse error (message on stderr).
 
+## Shell completions
+
+Generate and install a completion script with the `completions` subcommand:
+
+```bash
+# bash
+shahanshahi completions bash > ~/.local/share/bash-completion/completions/shahanshahi
+
+# zsh (add the directory to $fpath if not already there)
+shahanshahi completions zsh > ~/.config/zsh/completions/_shahanshahi
+
+# fish
+shahanshahi completions fish > ~/.config/fish/completions/shahanshahi.fish
+
+# PowerShell
+shahanshahi completions powershell > shahanshahi.ps1
+# then add `. ./shahanshahi.ps1` to your $PROFILE
+```
+
+After installing, restart your shell (or source the file) to activate tab-completion for subcommands, flags, and calendar names.
+
 ## Examples
 
 ```bash
@@ -91,6 +112,10 @@ shahanshahi convert 1976-03-21
 
 shahanshahi convert --from sh --to g 2535-01-01
 # 1976-03-21
+
+# Human-readable month names
+shahanshahi convert 1976-03-21 --month-names
+# 1 Farvardin 2535
 
 # Batch from stdin
 printf "1976-03-21\n1977-03-21\n" | shahanshahi convert


### PR DESCRIPTION
## Summary

- Adds `clap_complete 4` dependency to `shahanshahi-cli`
- Adds `completions` subcommand that prints a shell completion script to stdout
- Documents installation for all four shells in `docs/CLI.md`
- Also adds the `--month-names` example to the Examples section (carried over from #56)

## How to verify

```bash
# Generate and inspect bash completions
shahanshahi completions bash | grep -E "convert|completions|month-names"

# Write to file (no broken-pipe panic)
shahanshahi completions fish > /tmp/test.fish && wc -l /tmp/test.fish

# All four shells
shahanshahi completions bash
shahanshahi completions zsh
shahanshahi completions fish
shahanshahi completions powershell
```

Completions include all subcommands, flags, and enum values (`gregorian`/`shahanshahi` for `--from`/`--to`, `text`/`json`/`csv` for `--format`).

## Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — 43 tests pass
- [x] Conventional Commit messages per commit
- [x] Closes #44