### PR TITLE
chore(release): shahanshahi-cli 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ as described in [`docs/ENGINEERING.md`](./docs/ENGINEERING.md).
 
 ## [Unreleased]
 
-### Added
-
-- `shahanshahi-cli` / `shahanshahi` binary for shell conversion ([`docs/CLI.md`](./docs/CLI.md), [#6](https://github.com/melliran/shahanshahi/issues/6)). Intended to ship with **`shahanshahi` 0.2.1** alongside **`shahanshahi-cli` 0.1.0** after the [CLI tooling](https://github.com/melliran/shahanshahi/milestone/2) milestone.
-
 ## [0.2.0] - 2026-03-22
 
 ### Added

--- a/crates/shahanshahi-cli/CHANGELOG.md
+++ b/crates/shahanshahi-cli/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to `shahanshahi-cli` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-06-04
+
+First release of the `shahanshahi-cli` crate.
+
+### Added
+
+- Batch/pipe-friendly CLI binary (`shahanshahi` / `shcal`) for Shahanshahi ↔ Gregorian conversion ([#48](https://github.com/melliran/shahanshahi/pull/48), [#6](https://github.com/melliran/shahanshahi/issues/6))
+- Human-readable Persian month names in text output ([#56](https://github.com/melliran/shahanshahi/pull/56))
+- Shell completion scripts for bash, zsh, fish, and PowerShell (`shcal completions <shell>`) ([#59](https://github.com/melliran/shahanshahi/pull/59))
+- `shcal` short binary alias alongside the `shahanshahi` binary ([#60](https://github.com/melliran/shahanshahi/pull/60))


### PR DESCRIPTION
## Summary

- First release of `shahanshahi-cli` v0.1.0
- `shahanshahi` library stays at v0.2.0 (no code changes since that tag)

## What's in 0.1.0

- Batch/pipe-friendly CLI binary (`shahanshahi` / `shcal`) for Shahanshahi ↔ Gregorian conversion (#48)
- Human-readable Persian month names in text output (#56)
- Shell completion scripts for bash, zsh, fish, and PowerShell (#59)
- `shcal` short binary alias (#60)

## Changes in this PR

- `crates/shahanshahi-cli/CHANGELOG.md` — created for first CLI release
- `CHANGELOG.md` — cleared stale `[Unreleased]` entry that referenced a `shahanshahi` 0.2.1 that isn't happening

## Motivation

`shahanshahi-cli` 0.1.0 has all planned CLI milestone features merged but has never been published to crates.io. This PR cuts the first release.

## How to verify

```
cargo test --workspace --all-features
cargo clippy --workspace --all-targets --all-features -- -D warnings
```

After merging: confirm `shahanshahi-cli-v0.1.0` tag + GitHub release are created, then publish.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`