### PR TITLE
fix(cli): add README.md for crates.io display (0.1.1)

### DIFF
--- a/crates/shahanshahi-cli/CHANGELOG.md
+++ b/crates/shahanshahi-cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `shahanshahi-cli` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-06-05
+
+### Added
+
+- `README.md` for crates.io display
+
 ## [0.1.0] - 2026-06-04
 
 First release of the `shahanshahi-cli` crate.

--- a/crates/shahanshahi-cli/Cargo.toml
+++ b/crates/shahanshahi-cli/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "shahanshahi-cli"
 description = "CLI for Shahanshahi (Imperial Iranian) ↔ Gregorian date conversion"
-version = "0.1.0"
+version = "0.1.1"
+readme = "README.md"
 default-run = "shahanshahi"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/shahanshahi-cli/README.md
+++ b/crates/shahanshahi-cli/README.md
@@ -1,0 +1,89 @@
+# shahanshahi-cli
+
+Command-line tool for deterministic offline conversion between the **Shahanshahi (Imperial Iranian) civil calendar** and the proleptic Gregorian calendar.
+
+Installs two binaries: **`shahanshahi`** (full name) and **`shcal`** (short alias). Both expose the same conversion logic from the [`shahanshahi`](https://crates.io/crates/shahanshahi) library.
+
+## Install
+
+```bash
+cargo install shahanshahi-cli
+```
+
+## Usage
+
+```text
+shahanshahi convert [OPTIONS] [DATE]
+shahanshahi completions <SHELL>
+```
+
+`DATE` is a civil date as `YYYY-MM-DD`. Omit it (or pass `-`) to read batch input from stdin.
+
+### Options
+
+| Flag | Meaning |
+|------|---------|
+| `--from <calendar>` | Source: `gregorian` (`g`, `greg`) or `shahanshahi` (`sh`, `s`) |
+| `--to <calendar>` | Target (same values) |
+| `-f`, `--format <fmt>` | `text` (default), `json`, or `csv` |
+| `--month-names` | Print human-readable Persian month names in text output |
+| `--proleptic` | Allow Shahanshahi dates outside the legal civil era |
+
+If only one of `--from` / `--to` is set, the other is inferred. Default direction is Gregorian → Shahanshahi.
+
+## Examples
+
+```bash
+# Gregorian → Shahanshahi
+shahanshahi convert 1976-03-21
+# 2535-01-01
+
+# Shahanshahi → Gregorian
+shahanshahi convert --from sh --to g 2535-01-01
+# 1976-03-21
+
+# Human-readable month names
+shahanshahi convert 1976-03-21 --month-names
+# 1 Farvardin 2535
+
+# Batch from stdin
+printf "1976-03-21\n1977-03-21\n" | shahanshahi convert
+
+# JSON batch
+echo '[{"year":1976,"month":3,"day":21}]' | shahanshahi convert -f json
+
+# CSV batch
+printf "year,month,day\n1976,3,21\n" | shahanshahi convert -f csv
+```
+
+## Shell completions
+
+```bash
+# bash
+shahanshahi completions bash > ~/.local/share/bash-completion/completions/shahanshahi
+
+# zsh
+shahanshahi completions zsh > ~/.config/zsh/completions/_shahanshahi
+
+# fish
+shahanshahi completions fish > ~/.config/fish/completions/shahanshahi.fish
+
+# PowerShell
+shahanshahi completions powershell > shahanshahi.ps1
+```
+
+## Output formats
+
+**`text`** — one `YYYY-MM-DD` line per input date (default).  
+**`json`** — single object `{"year":…,"month":…,"day":…}` or array in batch mode.  
+**`csv`** — `year,month,day` header + data rows.
+
+## Exit codes
+
+- `0` — success
+- `1` — parse or conversion error (message on stderr)
+
+## See also
+
+- [`shahanshahi`](https://crates.io/crates/shahanshahi) — the underlying library crate
+- [SPEC.md](https://github.com/melliran/shahanshahi/blob/main/SPEC.md) — era bounds and conversion algorithm


### PR DESCRIPTION
## Summary

- Adds `crates/shahanshahi-cli/README.md` (shown on crates.io)
- Adds `readme = "README.md"` to `Cargo.toml`
- Bumps `shahanshahi-cli` to 0.1.1 (crates.io reads readme from the published package, so 0.1.0 can't be patched retroactively)

## How to verify

Merge → tag `shahanshahi-cli-v0.1.1` → `cargo publish -p shahanshahi-cli` → confirm readme appears on crates.io/crates/shahanshahi-cli.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`