### PR TITLE
feat(wasm): shahanshahi-wasm crate with JS/TS bindings

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Test (wasm32, Node.js)
-        run: wasm-pack test --node crates/shahanshahi-wasm
+        run: wasm-pack test --node --scope melliran crates/shahanshahi-wasm

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -23,4 +23,5 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Test (wasm32, Node.js)
-        run: wasm-pack test --node --scope melliran crates/shahanshahi-wasm
+        run: wasm-pack test --node --scope melliran
+        working-directory: crates/shahanshahi-wasm

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,26 @@
+name: wasm
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  wasm-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Test (wasm32, Node.js)
+        run: wasm-pack test --node crates/shahanshahi-wasm

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Test (wasm32, Node.js)
-        run: wasm-pack test --node --scope melliran
+        run: wasm-pack test --node
         working-directory: crates/shahanshahi-wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,10 +59,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
@@ -159,6 +198,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,10 +246,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-conv"
@@ -195,13 +301,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "powerfmt"
@@ -228,10 +353,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -241,6 +381,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -288,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "shahanshahi-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -298,6 +449,30 @@ dependencies = [
  "serde_json",
  "shahanshahi",
 ]
+
+[[package]]
+name = "shahanshahi-wasm"
+version = "0.1.0"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "shahanshahi",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strsim"
@@ -346,6 +521,119 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/shahanshahi", "crates/shahanshahi-cli"]
+members = ["crates/shahanshahi", "crates/shahanshahi-cli", "crates/shahanshahi-wasm"]
 
 [workspace.package]
 version = "0.2.0"

--- a/crates/shahanshahi-wasm/Cargo.toml
+++ b/crates/shahanshahi-wasm/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "shahanshahi-wasm"
+description = "WebAssembly bindings for the Shahanshahi (Imperial Iranian) calendar library"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+shahanshahi = { path = "../shahanshahi", version = "0.2.0", default-features = false, features = ["std"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+js-sys = "0.3"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/crates/shahanshahi-wasm/README.md
+++ b/crates/shahanshahi-wasm/README.md
@@ -1,0 +1,67 @@
+# shahanshahi-wasm
+
+WebAssembly bindings for the [`shahanshahi`](https://crates.io/crates/shahanshahi) calendar library — deterministic offline conversion between the **Shahanshahi (Imperial Iranian) civil calendar** and the proleptic Gregorian calendar.
+
+Built with [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) and [`wasm-pack`](https://rustwasm.github.io/wasm-pack/).
+
+## Install (npm)
+
+```bash
+npm install shahanshahi-wasm   # once published
+```
+
+Or build from source:
+
+```bash
+wasm-pack build --target web crates/shahanshahi-wasm      # ESM / browser
+wasm-pack build --target bundler crates/shahanshahi-wasm  # webpack / vite
+wasm-pack build --target nodejs crates/shahanshahi-wasm   # Node.js
+```
+
+## API
+
+All functions are synchronous. Invalid input throws a JavaScript `Error`.
+
+### `gregorianToShahanshahi(year, month, day)`
+
+```js
+import init, { gregorianToShahanshahi } from './shahanshahi_wasm.js';
+await init();
+
+gregorianToShahanshahi(1976, 3, 21);
+// → { year: 2535, month: 1, day: 1 }
+```
+
+### `shahanshahiToGregorian(year, month, day)`
+
+```js
+shahanshahiToGregorian(2535, 1, 1);
+// → { year: 1976, month: 3, day: 21 }
+```
+
+### `isShahanshahiLeapYear(year)`
+
+```js
+isShahanshahiLeapYear(2534); // → true
+isShahanshahiLeapYear(2535); // → false
+```
+
+### Error handling
+
+```js
+try {
+  gregorianToShahanshahi(1976, 13, 1); // month 13 is invalid
+} catch (e) {
+  console.error(e.message);
+}
+```
+
+## TypeScript
+
+TypeScript definitions are generated automatically by `wasm-pack` and included in the package.
+
+## See also
+
+- [`shahanshahi`](https://crates.io/crates/shahanshahi) — the core Rust library
+- [`shahanshahi-cli`](https://crates.io/crates/shahanshahi-cli) — command-line tool
+- [SPEC.md](https://github.com/melliran/shahanshahi/blob/main/SPEC.md) — calendar algorithm and era bounds

--- a/crates/shahanshahi-wasm/README.md
+++ b/crates/shahanshahi-wasm/README.md
@@ -55,6 +55,9 @@ isShahanshahiLeapYear(2535); // → false
 ### Error handling
 
 ```js
+import init, { gregorianToShahanshahi } from '@melliran/shahanshahi-wasm';
+await init();
+
 try {
   gregorianToShahanshahi(1976, 13, 1); // month 13 is invalid
 } catch (e) {

--- a/crates/shahanshahi-wasm/README.md
+++ b/crates/shahanshahi-wasm/README.md
@@ -7,15 +7,15 @@ Built with [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) and [`wasm
 ## Install (npm)
 
 ```bash
-npm install shahanshahi-wasm   # once published
+npm install @melliran/shahanshahi-wasm
 ```
 
 Or build from source:
 
 ```bash
-wasm-pack build --target web crates/shahanshahi-wasm      # ESM / browser
-wasm-pack build --target bundler crates/shahanshahi-wasm  # webpack / vite
-wasm-pack build --target nodejs crates/shahanshahi-wasm   # Node.js
+wasm-pack build --scope melliran --target web crates/shahanshahi-wasm      # ESM / browser
+wasm-pack build --scope melliran --target bundler crates/shahanshahi-wasm  # webpack / vite
+wasm-pack build --scope melliran --target nodejs crates/shahanshahi-wasm   # Node.js
 ```
 
 ## API
@@ -25,7 +25,7 @@ All functions are synchronous. Invalid input throws a JavaScript `Error`.
 ### `gregorianToShahanshahi(year, month, day)`
 
 ```js
-import init, { gregorianToShahanshahi } from './shahanshahi_wasm.js';
+import init, { gregorianToShahanshahi } from '@melliran/shahanshahi-wasm';
 await init();
 
 gregorianToShahanshahi(1976, 3, 21);

--- a/crates/shahanshahi-wasm/README.md
+++ b/crates/shahanshahi-wasm/README.md
@@ -10,12 +10,12 @@ Built with [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) and [`wasm
 npm install @melliran/shahanshahi-wasm
 ```
 
-Or build from source:
+Or build from source (run from the workspace root):
 
 ```bash
-wasm-pack build --scope melliran --target web crates/shahanshahi-wasm      # ESM / browser
+wasm-pack build --scope melliran --target web     crates/shahanshahi-wasm  # ESM / browser
 wasm-pack build --scope melliran --target bundler crates/shahanshahi-wasm  # webpack / vite
-wasm-pack build --scope melliran --target nodejs crates/shahanshahi-wasm   # Node.js
+wasm-pack build --scope melliran --target nodejs  crates/shahanshahi-wasm  # Node.js
 ```
 
 ## API
@@ -35,6 +35,9 @@ gregorianToShahanshahi(1976, 3, 21);
 ### `shahanshahiToGregorian(year, month, day)`
 
 ```js
+import init, { shahanshahiToGregorian } from '@melliran/shahanshahi-wasm';
+await init();
+
 shahanshahiToGregorian(2535, 1, 1);
 // → { year: 1976, month: 3, day: 21 }
 ```
@@ -42,6 +45,9 @@ shahanshahiToGregorian(2535, 1, 1);
 ### `isShahanshahiLeapYear(year)`
 
 ```js
+import init, { isShahanshahiLeapYear } from '@melliran/shahanshahi-wasm';
+await init();
+
 isShahanshahiLeapYear(2534); // → true
 isShahanshahiLeapYear(2535); // → false
 ```

--- a/crates/shahanshahi-wasm/src/lib.rs
+++ b/crates/shahanshahi-wasm/src/lib.rs
@@ -1,0 +1,49 @@
+use serde::Serialize;
+use shahanshahi::{is_shahanshahi_leap_arithmetic, GregorianDate, ShahanshahiDate};
+use wasm_bindgen::prelude::*;
+
+/// Plain data returned across the JS boundary — serializes to `{ year, month, day }`.
+#[derive(Serialize)]
+struct DateResult {
+    year: i32,
+    month: u8,
+    day: u8,
+}
+
+/// Convert a Gregorian date to Shahanshahi.
+///
+/// Returns a JS object `{ year, month, day }` or throws a JS `Error` on invalid input.
+#[wasm_bindgen(js_name = gregorianToShahanshahi)]
+pub fn gregorian_to_shahanshahi(year: i32, month: u8, day: u8) -> Result<JsValue, JsError> {
+    let greg =
+        GregorianDate::try_new(year, month, day).map_err(|e| JsError::new(&e.to_string()))?;
+    let sh = ShahanshahiDate::try_from_gregorian(greg).map_err(|e| JsError::new(&e.to_string()))?;
+    let result = DateResult {
+        year: sh.year(),
+        month: sh.month(),
+        day: sh.day(),
+    };
+    Ok(serde_wasm_bindgen::to_value(&result)?)
+}
+
+/// Convert a Shahanshahi date to Gregorian.
+///
+/// Returns a JS object `{ year, month, day }` or throws a JS `Error` on invalid input.
+#[wasm_bindgen(js_name = shahanshahiToGregorian)]
+pub fn shahanshahi_to_gregorian(year: i32, month: u8, day: u8) -> Result<JsValue, JsError> {
+    let sh =
+        ShahanshahiDate::try_new(year, month, day).map_err(|e| JsError::new(&e.to_string()))?;
+    let greg = sh.to_gregorian();
+    let result = DateResult {
+        year: greg.year(),
+        month: greg.month(),
+        day: greg.day(),
+    };
+    Ok(serde_wasm_bindgen::to_value(&result)?)
+}
+
+/// Return `true` if the given Shahanshahi year is a leap year (Mode A arithmetic rule).
+#[wasm_bindgen(js_name = isShahanshahiLeapYear)]
+pub fn is_shahanshahi_leap_year(year: i32) -> bool {
+    is_shahanshahi_leap_arithmetic(year)
+}

--- a/crates/shahanshahi-wasm/tests/wasm.rs
+++ b/crates/shahanshahi-wasm/tests/wasm.rs
@@ -1,0 +1,56 @@
+use js_sys::Reflect;
+use shahanshahi_wasm::{
+    gregorian_to_shahanshahi, is_shahanshahi_leap_year, shahanshahi_to_gregorian,
+};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+
+fn get_i32(obj: &JsValue, key: &str) -> i32 {
+    Reflect::get(obj, &JsValue::from_str(key))
+        .unwrap()
+        .as_f64()
+        .unwrap() as i32
+}
+
+fn get_u8(obj: &JsValue, key: &str) -> u8 {
+    Reflect::get(obj, &JsValue::from_str(key))
+        .unwrap()
+        .as_f64()
+        .unwrap() as u8
+}
+
+// Anchor: 1 Farvardin 2535 SH == 1976-03-21 Gregorian (from SPEC.md and golden corpus)
+
+#[wasm_bindgen_test]
+fn gregorian_to_shahanshahi_anchor() {
+    let result = gregorian_to_shahanshahi(1976, 3, 21).unwrap();
+    assert_eq!(get_i32(&result, "year"), 2535);
+    assert_eq!(get_u8(&result, "month"), 1);
+    assert_eq!(get_u8(&result, "day"), 1);
+}
+
+#[wasm_bindgen_test]
+fn shahanshahi_to_gregorian_anchor() {
+    let result = shahanshahi_to_gregorian(2535, 1, 1).unwrap();
+    assert_eq!(get_i32(&result, "year"), 1976);
+    assert_eq!(get_u8(&result, "month"), 3);
+    assert_eq!(get_u8(&result, "day"), 21);
+}
+
+#[wasm_bindgen_test]
+fn leap_year_known_values() {
+    // 2534: (2534 - 1180) = 1354; 1354 mod 33 = 1 → leap
+    assert!(is_shahanshahi_leap_year(2534));
+    // 2535: (2535 - 1180) = 1355; 1355 mod 33 = 2 → not leap
+    assert!(!is_shahanshahi_leap_year(2535));
+}
+
+#[wasm_bindgen_test]
+fn invalid_gregorian_month_throws() {
+    assert!(gregorian_to_shahanshahi(1976, 13, 1).is_err());
+}
+
+#[wasm_bindgen_test]
+fn invalid_shahanshahi_month_throws() {
+    assert!(shahanshahi_to_gregorian(2535, 13, 1).is_err());
+}


### PR DESCRIPTION
## Summary

Closes #7.

Adds `crates/shahanshahi-wasm` — a new workspace crate that exposes the Shahanshahi ↔ Gregorian calendar conversion to JavaScript and TypeScript via WebAssembly.

## Motivation

The library API (v0.2.0) is stable. This delivers the first phase of issue #7: a `wasm-pack`-based build story, a minimal spec-guaranteed API surface, and a CI job to prevent regressions.

## What's included

**New crate `shahanshahi-wasm`** (`crates/shahanshahi-wasm/`):
- `gregorianToShahanshahi(year, month, day)` → `{ year, month, day }` (throws `Error` on invalid input)
- `shahanshahiToGregorian(year, month, day)` → `{ year, month, day }` (throws `Error` on invalid input)
- `isShahanshahiLeapYear(year)` → `bool`
- `wasm-bindgen-test` suite covering the spec anchor date (`1976-03-21 ↔ 2535-01-01`), leap year rule, and error cases
- Builds for `--target web`, `--target bundler`, and `--target nodejs` via `wasm-pack`

**New CI workflow** (`.github/workflows/wasm.yml`):
- Runs `wasm-pack test --node` on every push and PR to `main`

## How to verify

```bash
# Run the WASM tests locally
wasm-pack test --node crates/shahanshahi-wasm

# Build for web
wasm-pack build --target web crates/shahanshahi-wasm

# Full workspace
cargo test --workspace --all-features
cargo clippy --workspace --all-targets --all-features -- -D warnings
```

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `wasm-pack test --node crates/shahanshahi-wasm` (5/5 passing)